### PR TITLE
Add python3 command in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ for fcmm in ./tests/*.cmm; do
 
   $RUN ./workdir/a.cmm > ./workdir/a.out 2>&1
 
-  if ./check.py; then
+  if python3 ./check.py; then
     echo test [$(basename $fcmm)] matched
   else
     echo -e "${RED}${BOLD}test [$(basename $fcmm)] mismatch${NC}${NORMAL}"


### PR DESCRIPTION
Not all system has `#!/bin/python` link to python3 interpreter, should use command, instead.