### PR TITLE
Fix .gitignore BUG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-workdir/*	
+workdir/*
 irsim-py/	
 parser	
 my.sh


### PR DESCRIPTION
A tailing `\t` after `workdir/*`, which cause it failed to be ignored.